### PR TITLE
[WIP] jestify-II

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,17 +1,34 @@
 {
   "env": {
     "es6": true,
-    "node": true
+    "node": true,
+    "jest": true
   },
   "extends": "eslint:recommended",
   "rules": {
-    "indent": ["error", 2],
-    "linebreak-style": ["error", "unix"],
-    "quotes": ["error", "single", {
-      "avoidEscape": true,
-      "allowTemplateLiterals": true
-    }],
-    "semi": ["error", "always"],
-    "strict": ["error", "safe"]
+    "indent": [
+      "error",
+      2
+    ],
+    "linebreak-style": [
+      "error",
+      "unix"
+    ],
+    "quotes": [
+      "error",
+      "single",
+      {
+        "avoidEscape": true,
+        "allowTemplateLiterals": true
+      }
+    ],
+    "semi": [
+      "error",
+      "always"
+    ],
+    "strict": [
+      "error",
+      "safe"
+    ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ results
 
 npm-debug.log
 node_modules
+coverage

--- a/__tests__/__snapshots__/components-renderer.test.js.snap
+++ b/__tests__/__snapshots__/components-renderer.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`componentsRenderer happy path 1`] = `
+Array [
+  Array [
+    null,
+    Array [
+      undefined,
+    ],
+  ],
+]
+`;
+
+exports[`componentsRenderer has errors 1`] = `
+Array [
+  Array [
+    Array [
+      "something bad happened",
+    ],
+    Array [
+      undefined,
+    ],
+  ],
+]
+`;

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`client api client api to match snapshot 1`] = `
+Object {
+  "getComponentsInfo": [Function],
+  "init": [Function],
+  "renderComponent": [Function],
+  "renderComponents": [Function],
+  "renderTemplate": [Function],
+}
+`;
+
+exports[`error 1`] = `"Configuration is not valid: registries must contain at least one endpoint"`;

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -1,15 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`client api client api to match snapshot 1`] = `
-Object {
-  "getComponentsInfo": [Function],
-  "init": [Function],
-  "renderComponent": [Function],
-  "renderComponents": [Function],
-  "renderTemplate": [Function],
-}
-`;
-
 exports[`client api to match snapshot 1`] = `
 Object {
   "getComponentsInfo": [Function],

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -10,4 +10,14 @@ Object {
 }
 `;
 
+exports[`client api to match snapshot 1`] = `
+Object {
+  "getComponentsInfo": [Function],
+  "init": [Function],
+  "renderComponent": [Function],
+  "renderComponents": [Function],
+  "renderTemplate": [Function],
+}
+`;
+
 exports[`error 1`] = `"Configuration is not valid: registries must contain at least one endpoint"`;

--- a/__tests__/__snapshots__/sanitiser.test.js.snap
+++ b/__tests__/__snapshots__/sanitiser.test.js.snap
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sanitiseConfiguration 1`] = `
+Object {
+  "cache": Object {},
+  "components": Object {},
+}
+`;
+
+exports[`sanitiseGlobalGetInfoOptions 1`] = `
+Object {
+  "headers": Object {
+    "accept": "application/vnd.oc.info+json",
+    "user-agent": "oc-client-2.1.21/v8.2.1-darwin-x64",
+  },
+  "timeout": 5,
+}
+`;
+
+exports[`sanitiseGlobalRenderOptions all empty 1`] = `
+Object {
+  "container": false,
+  "headers": Object {
+    "accept": "application/vnd.oc.unrendered+json",
+    "user-agent": "oc-client-2.1.21/v8.2.1-darwin-x64",
+  },
+  "renderInfo": true,
+  "timeout": 5,
+}
+`;
+
+exports[`sanitiseGlobalRenderOptions clientRendering is false 1`] = `
+Object {
+  "container": false,
+  "disableFailoverRendering": true,
+  "headers": Object {
+    "accept": "application/vnd.oc.unrendered+json",
+    "user-agent": "oc-client-2.1.21/v8.2.1-darwin-x64",
+  },
+  "renderInfo": true,
+  "timeout": 5,
+}
+`;
+
+exports[`sanitiseGlobalRenderOptions container is true and renderInfo is false 1`] = `
+Object {
+  "container": true,
+  "headers": Object {
+    "accept": "application/vnd.oc.unrendered+json",
+    "user-agent": "oc-client-2.1.21/v8.2.1-darwin-x64",
+  },
+  "renderInfo": false,
+  "timeout": 5,
+}
+`;
+
+exports[`sanitiseGlobalRenderOptions options is a function 1`] = `
+Object {
+  "container": false,
+  "headers": Object {
+    "accept": "application/vnd.oc.unrendered+json",
+    "user-agent": "oc-client-2.1.21/v8.2.1-darwin-x64",
+  },
+  "renderInfo": true,
+  "timeout": 5,
+}
+`;
+
+exports[`sanitiseGlobalRenderOptions options is a function 2`] = `
+Object {
+  "container": false,
+  "headers": Object {
+    "accept": "application/vnd.oc.unrendered+json",
+    "user-agent": "oc-client-2.1.21/v8.2.1-darwin-x64",
+  },
+  "renderInfo": true,
+  "timeout": 5,
+}
+`;
+
+exports[`sanitiseGlobalRenderOptions options w/ headers 1`] = `
+Object {
+  "container": false,
+  "headers": Object {
+    "accept": "application/vnd.oc.unrendered+json",
+    "user-agent": "oc-client-2.1.21/v8.2.1-darwin-x64",
+    "x-ot-channel": "MobileWeb",
+  },
+  "renderInfo": true,
+  "timeout": 5,
+}
+`;
+
+exports[`sanitiser api 1`] = `
+Object {
+  "sanitiseConfiguration": [Function],
+  "sanitiseGlobalGetInfoOptions": [Function],
+  "sanitiseGlobalRenderOptions": [Function],
+}
+`;

--- a/__tests__/__snapshots__/template-renderer.test.js.snap
+++ b/__tests__/__snapshots__/template-renderer.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`bad template type 1`] = `
+Array [
+  Array [
+    "Error requiring oc-template: \\"unsupported\\" not found",
+  ],
+]
+`;
+
+exports[`handlebars 1`] = `
+Array [
+  Array [
+    [TypeError: Cannot read property 'compiler' of null],
+  ],
+]
+`;
+
+exports[`jade 1`] = `
+Array [
+  Array [
+    [TypeError: options.template is not a function],
+    "<oc-component href=\\"{0}\\" data-hash=\\"{1}\\" data-name=\\"\\" data-rendered=\\"true\\" data-version=\\"{3}\\">{4}</oc-component>",
+  ],
+]
+`;

--- a/__tests__/__snapshots__/validator.test.js.snap
+++ b/__tests__/__snapshots__/validator.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`conf is an empty object 1`] = `
+Object {
+  "isValid": true,
+}
+`;
+
+exports[`conf.registries is a valid object 1`] = `
+Object {
+  "isValid": true,
+}
+`;
+
+exports[`conf.registries is an empty array 1`] = `
+Object {
+  "error": "Configuration is not valid: registries must be an object",
+  "isValid": false,
+}
+`;
+
+exports[`conf.registries is an empty object 1`] = `
+Object {
+  "error": "Configuration is not valid: registries must contain at least one endpoint",
+  "isValid": false,
+}
+`;
+
+exports[`validator api 1`] = `
+Object {
+  "validateConfiguration": [Function],
+}
+`;

--- a/__tests__/components-renderer.test.js
+++ b/__tests__/components-renderer.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const ComponentsRenderer = require('../src/components-renderer');
+jest.mock('../src/get-components-data');
+
+test('ComponentsRenderer (factory) is a function', () => {
+  expect(typeof ComponentsRenderer).toEqual('function');
+});
+
+test('componentsRenderer (instance) is a function api', () => {
+  const config = {};
+  const componentsRenderer = new ComponentsRenderer(config);
+  expect(typeof componentsRenderer).toEqual('function');
+});
+
+test('componentsRenderer happy path', () => {
+  const config = {};
+  const componentsRenderer = new ComponentsRenderer(config);
+  const components = [
+    {
+      name: 'good',
+      version: '1.0.0'
+    }
+  ];
+  const callback = jest.fn();
+  componentsRenderer(components, null, callback);
+  expect(callback).toHaveBeenCalled();
+  expect(callback.mock.calls).toMatchSnapshot();
+});
+
+test('componentsRenderer has errors', () => {
+  const config = {
+    components: {
+      'bad': '1.0.0'
+    }
+  };
+  const componentsRenderer = new ComponentsRenderer(config);
+  const components = [
+    {
+      name: 'bad'
+    }
+  ];
+  const callback = jest.fn();
+  componentsRenderer(components, null, callback);
+  expect(callback).toHaveBeenCalled();
+  expect(callback.mock.calls).toMatchSnapshot();
+});

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const client = require('../src');
+jest.mock('../src/components-renderer');
+jest.mock('../src/get-components-info');
+jest.mock('../src/warmup');
+
+test('typeof client to equal "function"', () => {
+  expect(typeof client).toEqual('function');
+});
+
+describe('client api', () => {
+  const api = client();
+
+  test('client api to match snapshot', () => {
+    expect(api).toMatchSnapshot();
+  });
+
+  test('getComponentsInfo callback to have been called', () => {
+    const callback = jest.fn();
+    api.getComponentsInfo(null, callback);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  test('init callback to have been called', () => {
+    const callback = jest.fn();
+    api.init(null, callback);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  test('renderComponent (w/ 2 params) callback to have been called', () => {
+    const callback = jest.fn();
+    api.renderComponent('good', callback);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  test('renderComponent (w/ 3 params) callback to have been called', () => {
+    const callback = jest.fn();
+    api.renderComponent('bad', {}, callback);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  test('renderComponents (w/ 2 params) callback to have been called', () => {
+    const callback = jest.fn();
+    api.renderComponents([{ name: 'bad' }], callback);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  test('renderComponents (w/ 3 params) callback to have been called', () => {
+    const callback = jest.fn();
+    api.renderComponents([{ name: 'good' }], {}, callback);
+    expect(callback).toHaveBeenCalled();
+  });
+});
+
+test('error', () => {
+  expect(() => {
+    client({ registries: {} });
+  }).toThrowErrorMatchingSnapshot();
+});

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -12,7 +12,7 @@ test('typeof client to equal "function"', () => {
 describe('client api', () => {
   const api = client();
 
-  test('client api to match snapshot', () => {
+  test('to match snapshot', () => {
     expect(api).toMatchSnapshot();
   });
 

--- a/__tests__/sanitiser.test.js
+++ b/__tests__/sanitiser.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const sanitiser = require('../src/sanitiser');
+
+test('sanitiser api', () => {
+  expect(sanitiser).toMatchSnapshot();
+});
+
+test('sanitiseConfiguration', () => {
+  const result = sanitiser.sanitiseConfiguration();
+  expect(result).toMatchSnapshot();
+});
+
+test('sanitiseGlobalGetInfoOptions', () => {
+  const result = sanitiser.sanitiseGlobalGetInfoOptions();
+  expect(result).toMatchSnapshot();
+});
+
+describe('sanitiseGlobalRenderOptions', () => {
+  const scenarios = [
+    {
+      description: 'all empty',
+      options: {},
+      config: {}
+    },
+    {
+      description: 'clientRendering is false',
+      options: {},
+      config: { registries: { clientRendering: false } }
+    },
+    {
+      description: 'options is a function',
+      options: jest.fn(),
+      config: {}
+    },
+    {
+      description: 'options is a function',
+      options: jest.fn(),
+      config: {}
+    },
+    {
+      description: 'options w/ headers',
+      options: { headers: { 'X-OT-Channel': 'MobileWeb' } },
+      config: {}
+    },
+    {
+      description: 'container is true and renderInfo is false',
+      options: { container: true, renderInfo: false },
+      config: {}
+    }
+  ];
+
+  scenarios.forEach(({ description, options, config }) => {
+    test(description, () => {
+      const result = sanitiser.sanitiseGlobalRenderOptions(options, config);
+      expect(result).toMatchSnapshot();
+    });
+  });
+});

--- a/__tests__/template-renderer.test.js
+++ b/__tests__/template-renderer.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const TemplateRenderer = require('../src/template-renderer');
+
+const templateRenderer = new TemplateRenderer(); // Q.: this is totally unecessary
+
+test('TemplateRenderer ctor', () => {
+  expect(typeof templateRenderer).toEqual('function');
+});
+
+const scenarios = [
+  {
+    description: 'bad template type',
+    template: null,
+    model: null,
+    options: { templateType: 'unsupported' }
+  },
+  {
+    description: 'jade',
+    template: null,
+    model: null,
+    options: { templateType: 'jade' }
+  },
+  {
+    description: 'handlebars',
+    template: null,
+    model: null,
+    options: { templateType: 'handlebars' }
+  }
+];
+
+scenarios.forEach(({ description, template, model, options }) => {
+  test(description, () => {
+    const callback = jest.fn();
+    // template, model, options, callback
+    templateRenderer(template, model, options, callback);
+    expect(callback).toHaveBeenCalled();
+    expect(callback.mock.calls).toMatchSnapshot();
+  });
+});

--- a/__tests__/template-renderer.test.js
+++ b/__tests__/template-renderer.test.js
@@ -32,7 +32,6 @@ const scenarios = [
 scenarios.forEach(({ description, template, model, options }) => {
   test(description, () => {
     const callback = jest.fn();
-    // template, model, options, callback
     templateRenderer(template, model, options, callback);
     expect(callback).toHaveBeenCalled();
     expect(callback.mock.calls).toMatchSnapshot();

--- a/__tests__/validator.test.js
+++ b/__tests__/validator.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const validator = require('../src/validator');
+
+test('validator api', () => {
+  expect(validator).toHaveProperty('validateConfiguration'); // Q.: why an object arount this only function then?
+  expect(validator).toMatchSnapshot();
+});
+
+const scenarios = [
+  {
+    description: 'conf is an empty object',
+    conf: {},
+    isValid: true // Q.: why this is valid?
+  },
+  {
+    description: 'conf.registries is an empty array',
+    conf: { registries: [] },
+    isValid: false
+  },
+  {
+    description: 'conf.registries is an empty object',
+    conf: { registries: {} },
+    isValid: false
+  },
+  {
+    description: 'conf.registries is a valid object',
+    conf: { registries: { serverRendering: 'http://registry.local:3030' } },
+    isValid: true
+  }
+];
+
+scenarios.forEach(({ description, conf, isValid }) => {
+  test(description, () => {
+    const result = validator.validateConfiguration(conf);
+    expect(result.isValid).toEqual(isValid);
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,9 +14,8 @@
   },
   "homepage": "https://github.com/opencomponents/oc-client-node",
   "scripts": {
-    "test": "mocha test/**/*.js",
-    "precommit": "lint-staged",
-    "jest": "jest"
+    "test": "mocha test/**/*.js && jest --coverage",
+    "precommit": "lint-staged"
   },
   "lint-staged": {
     "src/**/*.js": [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "homepage": "https://github.com/opencomponents/oc-client-node",
   "scripts": {
     "test": "mocha test/**/*.js",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "jest": "jest"
   },
   "lint-staged": {
     "src/**/*.js": [
@@ -34,13 +35,14 @@
   "devDependencies": {
     "chai": "3.5.0",
     "cheerio": "0.22.0",
+    "husky": "^0.14.3",
     "injectr": "0.5.1",
+    "jest": "^20.0.4",
+    "lint-staged": "^3.6.0",
     "mocha": "^3.0.2",
     "oc": "^0.38.8",
-    "sinon": "^1.17.5",
-    "husky": "^0.14.3",
     "prettier-eslint-cli": "^4.1.1",
-    "lint-staged": "^3.6.0"
+    "sinon": "^1.17.5"
   },
   "dependencies": {
     "minimal-request": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/opencomponents/oc-client-node",
   "scripts": {
-    "test": "mocha test/**/*.js && jest --coverage",
+    "test": "mocha test/**/*.js",
     "precommit": "lint-staged"
   },
   "lint-staged": {

--- a/src/__mocks__/components-renderer.js
+++ b/src/__mocks__/components-renderer.js
@@ -1,0 +1,15 @@
+'use strict';
+
+function ComponentsRenderer() {
+  return (components, options, callback) => {
+    const component = components[0];
+    if (component.name === 'good') {
+      callback(null, []);
+    }
+    if (component.name === 'bad') {
+      callback([], []);
+    }
+  };
+}
+
+module.exports = ComponentsRenderer;

--- a/src/__mocks__/get-components-data.js
+++ b/src/__mocks__/get-components-data.js
@@ -1,0 +1,16 @@
+'use strict';
+
+function GetComponentsData() {
+  return (toDo, options, cb) => {
+    if (toDo[0].component.name === 'good') {
+      cb();
+    }
+    if (toDo[0].component.name === 'bad') {
+      const message = 'something bad happened';
+      toDo[0].result.error = message; // Q.: this is bad :(
+      cb(message);
+    }
+  };
+}
+
+module.exports = GetComponentsData;

--- a/src/__mocks__/get-components-info.js
+++ b/src/__mocks__/get-components-info.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function GetComponentsInfo() {
+  return (components, callback) => {
+    callback();
+  };
+}
+
+module.exports = GetComponentsInfo;

--- a/src/__mocks__/process-client-responses.js
+++ b/src/__mocks__/process-client-responses.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function ProcessClientResponse() {
+  return (toDo, options, cb) => {
+    cb();
+  };
+}
+
+module.exports = ProcessClientResponse;

--- a/src/__mocks__/render-components.js
+++ b/src/__mocks__/render-components.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function RenderComponents() {
+  return (toDo, options, cb) => {
+    cb();
+  };
+}
+
+module.exports = RenderComponents;

--- a/src/__mocks__/warmup.js
+++ b/src/__mocks__/warmup.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function Warmup() {
+  return (options, callback) => {
+    callback();
+  };
+}
+
+module.exports = Warmup;


### PR DESCRIPTION
# Description

A slightly different approach compared with #4 re how to use `jest` to test this component.
This focuses more on unit testing 1st and code coverage so that it will be possible to refactor during a 2nd phase.

## SUT

Components that I'd like to have 100% covered

- [X] index.js

- [X] components-renderer.js

- [ ] get-components-info.js

- [X] sanitiser

- [X] template-renderer

- [X] validator

- [ ] warmup

## Report

```bash
 PASS  __tests__/sanitiser.test.js
 PASS  __tests__/components-renderer.test.js
 PASS  __tests__/validator.test.js
 PASS  __tests__/template-renderer.test.js
 PASS  __tests__/index.test.js

Test Suites: 5 passed, 5 total
Tests:       31 passed, 31 total
Snapshots:   21 passed, 21 total
Time:        0.359s, estimated 1s
Ran all test suites.
------------------------------|----------|----------|----------|----------|----------------|
File                          |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
------------------------------|----------|----------|----------|----------|----------------|
All files                     |    63.44 |    46.45 |    63.77 |    63.44 |                |
 src                          |    64.73 |    46.36 |    67.92 |    64.73 |                |
  components-renderer.js      |      100 |      100 |      100 |      100 |                |
  get-compiled-template.js    |    33.33 |        0 |       25 |    33.33 |... 49,54,55,63 |
  get-oc-client-script.js     |    71.43 |      100 |    33.33 |    71.43 |          10,13 |
  href-builder.js             |    17.65 |        0 |       25 |    17.65 |... 72,73,74,81 |
  html-renderer.js            |    77.78 |       50 |       50 |    77.78 |          10,27 |
  index.js                    |      100 |      100 |      100 |      100 |                |
  process-client-responses.js |    47.06 |    21.43 |       60 |    47.06 |... 51,57,58,64 |
  render-components.js        |    36.11 |    28.57 |    42.86 |    36.11 |... 74,77,78,80 |
  sanitiser.js                |      100 |      100 |      100 |      100 |                |
  settings.js                 |      100 |      100 |      100 |      100 |                |
  template-renderer.js        |      100 |      100 |      100 |      100 |                |
  templates.js                |      100 |      100 |      100 |      100 |                |
  try-get-cached.js           |       20 |        0 |    33.33 |       20 |... 12,13,16,17 |
  validator.js                |      100 |      100 |      100 |      100 |                |
 src/utils                    |    57.14 |    46.88 |       50 |    57.14 |                |
  helpers.js                  |       48 |    43.75 |    45.45 |       48 |... 47,50,51,54 |
  merge-objects.js            |     12.5 |        0 |        0 |     12.5 |... 13,14,15,16 |
  require-template.js         |    82.61 |    66.67 |      100 |    82.61 |    12,32,38,47 |
------------------------------|----------|----------|----------|----------|----------------|
```
