### PR TITLE
[OC-93] - Send supported templates as http header

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ It will create an instance of the client. Options:
 |`registries`|`object`|yes|The registries' endpoints|
 |`registries.serverRendering`|`string`|no|The baseUrl for server-side rendering requests|
 |`registries.clientRendering`|`string`|no|The baseUrl for client-side rendering requests|
+|`templates`|`array`|no|The templates available to the client, will extend the default: ['oc-template-handlebars', 'oc-template-jade']|
 
 Example:
 

--- a/src/get-components-info.js
+++ b/src/get-components-info.js
@@ -17,7 +17,7 @@ module.exports = function(config) {
       callback = options;
     }
 
-    options = sanitiser.sanitiseGlobalGetInfoOptions(options);
+    options = sanitiser.sanitiseGlobalGetInfoOptions(options, config);
 
     let serverRenderingEndpoint;
     if (

--- a/src/sanitiser.js
+++ b/src/sanitiser.js
@@ -35,11 +35,7 @@ const sanitiseDefaultOptions = function(options, config) {
   if (_.isFunction(options)) {
     options = {};
   }
-  config = config || {};
-  config.templates = config.templates || [
-    'oc-template-handlebars',
-    'oc-template-jade'
-  ];
+
   options = options || {};
   options.headers = lowerHeaderKeys(options.headers);
   options.headers['user-agent'] =
@@ -56,6 +52,10 @@ module.exports = {
     conf = conf || {};
     conf.components = conf.components || {};
     conf.cache = conf.cache || {};
+    conf.templates = conf.templates || [
+      'oc-template-handlebars',
+      'oc-template-jade'
+    ];
 
     return conf;
   },

--- a/src/sanitiser.js
+++ b/src/sanitiser.js
@@ -35,29 +35,29 @@ const sanitiseDefaultOptions = function(options, config) {
   if (_.isFunction(options)) {
     options = {};
   }
-  const copy = Object.assign({}, options);
-  copy.headers = lowerHeaderKeys(copy.headers);
-  copy.headers['user-agent'] =
-    copy.headers['user-agent'] || getDefaultUserAgent();
-  copy.headers.templates =
-    copy.headers.templates || getTemplatesInfo(config.templates);
+  const optionsCopy = Object.assign({}, options);
+  optionsCopy.headers = lowerHeaderKeys(optionsCopy.headers);
+  optionsCopy.headers['user-agent'] =
+    optionsCopy.headers['user-agent'] || getDefaultUserAgent();
+  optionsCopy.headers.templates =
+    optionsCopy.headers.templates || getTemplatesInfo(config.templates);
 
-  copy.timeout = copy.timeout || 5;
-  return copy;
+  optionsCopy.timeout = optionsCopy.timeout || 5;
+  return optionsCopy;
 };
 
 module.exports = {
   sanitiseDefaultOptions,
   sanitiseConfiguration: function(conf) {
     const baseTemplates = ['oc-template-handlebars', 'oc-template-jade'];
-    const copy = Object.assign({}, conf);
-    copy.components = copy.components || {};
-    copy.cache = copy.cache || {};
-    copy.templates = copy.templates
-      ? _.uniq(copy.templates.concat(baseTemplates))
+    const confCopy = Object.assign({}, conf);
+    confCopy.components = confCopy.components || {};
+    confCopy.cache = confCopy.cache || {};
+    confCopy.templates = confCopy.templates
+      ? _.uniq(confCopy.templates.concat(baseTemplates))
       : baseTemplates;
 
-    return copy;
+    return confCopy;
   },
 
   sanitiseGlobalRenderOptions: function(options, config) {

--- a/src/sanitiser.js
+++ b/src/sanitiser.js
@@ -35,31 +35,29 @@ const sanitiseDefaultOptions = function(options, config) {
   if (_.isFunction(options)) {
     options = {};
   }
+  const copy = Object.assign({}, options);
+  copy.headers = lowerHeaderKeys(copy.headers);
+  copy.headers['user-agent'] =
+    copy.headers['user-agent'] || getDefaultUserAgent();
+  copy.headers.templates =
+    copy.headers.templates || getTemplatesInfo(config.templates);
 
-  options = options || {};
-  options.headers = lowerHeaderKeys(options.headers);
-  options.headers['user-agent'] =
-    options.headers['user-agent'] || getDefaultUserAgent();
-  options.headers.templates =
-    options.headers.templates || getTemplatesInfo(config.templates);
-
-  options.timeout = options.timeout || 5;
-  return Object.assign({}, options);
+  copy.timeout = copy.timeout || 5;
+  return copy;
 };
 
 module.exports = {
   sanitiseDefaultOptions,
   sanitiseConfiguration: function(conf) {
     const baseTemplates = ['oc-template-handlebars', 'oc-template-jade'];
-
-    conf = conf || {};
-    conf.components = conf.components || {};
-    conf.cache = conf.cache || {};
-    conf.templates = conf.templates
-      ? _.uniq(conf.templates.concat(baseTemplates))
+    const copy = Object.assign({}, conf);
+    copy.components = copy.components || {};
+    copy.cache = copy.cache || {};
+    copy.templates = copy.templates
+      ? _.uniq(copy.templates.concat(baseTemplates))
       : baseTemplates;
 
-    return Object.assign({}, conf);
+    return copy;
   },
 
   sanitiseGlobalRenderOptions: function(options, config) {

--- a/src/sanitiser.js
+++ b/src/sanitiser.js
@@ -25,15 +25,27 @@ const getDefaultUserAgent = function() {
   );
 };
 
-const sanitiseDefaultOptions = function(options) {
+const getTemplatesInfo = templates =>
+  templates.reduce((templatesHash, template) => {
+    templatesHash[template] = require(template).getInfo().version;
+    return templatesHash;
+  }, {});
+
+const sanitiseDefaultOptions = function(options, config) {
   if (_.isFunction(options)) {
     options = {};
   }
-
+  config = config || {};
+  config.templates = config.templates || [
+    'oc-template-handlebars',
+    'oc-template-jade'
+  ];
   options = options || {};
   options.headers = lowerHeaderKeys(options.headers);
   options.headers['user-agent'] =
     options.headers['user-agent'] || getDefaultUserAgent();
+  options.headers.templates =
+    options.headers.templates || getTemplatesInfo(config.templates);
 
   options.timeout = options.timeout || 5;
   return options;
@@ -49,7 +61,7 @@ module.exports = {
   },
 
   sanitiseGlobalRenderOptions: function(options, config) {
-    options = sanitiseDefaultOptions(options);
+    options = sanitiseDefaultOptions(options, config);
     options.headers.accept = 'application/vnd.oc.unrendered+json';
 
     options.container = options.container === true ? true : false;
@@ -62,8 +74,8 @@ module.exports = {
     return options;
   },
 
-  sanitiseGlobalGetInfoOptions: function(options) {
-    options = sanitiseDefaultOptions(options);
+  sanitiseGlobalGetInfoOptions: function(options, config) {
+    options = sanitiseDefaultOptions(options, config);
     options.headers.accept = 'application/vnd.oc.info+json';
     return options;
   }

--- a/src/sanitiser.js
+++ b/src/sanitiser.js
@@ -44,7 +44,7 @@ const sanitiseDefaultOptions = function(options, config) {
     options.headers.templates || getTemplatesInfo(config.templates);
 
   options.timeout = options.timeout || 5;
-  return options;
+  return Object.assign({}, options);
 };
 
 module.exports = {
@@ -59,7 +59,7 @@ module.exports = {
       ? _.uniq(conf.templates.concat(baseTemplates))
       : baseTemplates;
 
-    return conf;
+    return Object.assign({}, conf);
   },
 
   sanitiseGlobalRenderOptions: function(options, config) {

--- a/src/sanitiser.js
+++ b/src/sanitiser.js
@@ -48,6 +48,7 @@ const sanitiseDefaultOptions = function(options, config) {
 };
 
 module.exports = {
+  sanitiseDefaultOptions,
   sanitiseConfiguration: function(conf) {
     const baseTemplates = ['oc-template-handlebars', 'oc-template-jade'];
 

--- a/src/sanitiser.js
+++ b/src/sanitiser.js
@@ -49,13 +49,14 @@ const sanitiseDefaultOptions = function(options, config) {
 
 module.exports = {
   sanitiseConfiguration: function(conf) {
+    const baseTemplates = ['oc-template-handlebars', 'oc-template-jade'];
+
     conf = conf || {};
     conf.components = conf.components || {};
     conf.cache = conf.cache || {};
-    conf.templates = conf.templates || [
-      'oc-template-handlebars',
-      'oc-template-jade'
-    ];
+    conf.templates = conf.templates
+      ? _.uniq(conf.templates.concat(baseTemplates))
+      : baseTemplates;
 
     return conf;
   },

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -52,6 +52,16 @@ const _ = {
     }
 
     return input;
+  },
+  uniq: function(array) {
+    const seen = {};
+    return input.reduce((uniques, element) => {
+      if (seen[element] !== element) {
+        seen[element] = element;
+        uniques = uniques.concat(element);
+      }
+      return uniques;
+    }, []);
   }
 };
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -54,17 +54,13 @@ const _ = {
     return input;
   },
   uniq: function(array) {
-    const seen = {};
-    let uniques = [];
+    let uniques = {};
 
     for (let i = 0; i < array.length; i++) {
-      const element = array[i];
-      if (seen[element] !== element) {
-        seen[element] = element;
-        uniques = uniques.concat(element);
-      }
+      uniques[array[i]] = true;
     }
-    return uniques;
+
+    return Object.keys(uniques);
   }
 };
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -55,7 +55,7 @@ const _ = {
   },
   uniq: function(array) {
     const seen = {};
-    return input.reduce((uniques, element) => {
+    return array.reduce((uniques, element) => {
       if (seen[element] !== element) {
         seen[element] = element;
         uniques = uniques.concat(element);

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -55,13 +55,16 @@ const _ = {
   },
   uniq: function(array) {
     const seen = {};
-    return array.reduce((uniques, element) => {
+    let uniques = [];
+
+    for (let i = 0; i < array.length; i++) {
+      const element = array[i];
       if (seen[element] !== element) {
         seen[element] = element;
         uniques = uniques.concat(element);
       }
-      return uniques;
-    }, []);
+    }
+    return uniques;
   }
 };
 

--- a/src/warmup.js
+++ b/src/warmup.js
@@ -3,12 +3,19 @@
 const format = require('stringformat');
 const request = require('minimal-request');
 
+const {
+  sanitiseDefaultOptions,
+  sanitiseConfiguration
+} = require('./sanitiser');
 const settings = require('./settings');
 const _ = require('./utils/helpers');
 
 module.exports = function(config, renderComponents) {
   return function(options, cb) {
     cb = cb || _.noop;
+
+    config = sanitiseConfiguration(config);
+    options = sanitiseDefaultOptions(options, config);
 
     if (!config || !config.registries || !config.registries.serverRendering) {
       return cb(null, {});

--- a/src/warmup.js
+++ b/src/warmup.js
@@ -3,10 +3,7 @@
 const format = require('stringformat');
 const request = require('minimal-request');
 
-const {
-  sanitiseDefaultOptions,
-  sanitiseConfiguration
-} = require('./sanitiser');
+const sanitiser = require('./sanitiser');
 const settings = require('./settings');
 const _ = require('./utils/helpers');
 
@@ -14,8 +11,8 @@ module.exports = function(config, renderComponents) {
   return function(options, cb) {
     cb = cb || _.noop;
 
-    config = sanitiseConfiguration(config);
-    options = sanitiseDefaultOptions(options, config);
+    config = sanitiser.sanitiseConfiguration(config);
+    options = sanitiser.sanitiseDefaultOptions(options, config);
 
     if (!config || !config.registries || !config.registries.serverRendering) {
       return cb(null, {});

--- a/test/unit/client-sanitiser.js
+++ b/test/unit/client-sanitiser.js
@@ -22,7 +22,8 @@ describe('client : sanitiser', () => {
 
   describe('when sanitising global rendering options', () => {
     describe('when user-agent not already set', () => {
-      const result = sanitiser.sanitiseGlobalRenderOptions({}, {});
+      const config = sanitiser.sanitiseConfiguration();
+      const result = sanitiser.sanitiseGlobalRenderOptions({}, config);
 
       it('should set oc-client user-agent', () => {
         expect(result.headers.templates).to.deep.equal({

--- a/test/unit/client-sanitiser.js
+++ b/test/unit/client-sanitiser.js
@@ -25,6 +25,11 @@ describe('client : sanitiser', () => {
       const result = sanitiser.sanitiseGlobalRenderOptions({}, {});
 
       it('should set oc-client user-agent', () => {
+        expect(result.headers.templates).to.deep.equal({
+          'oc-template-handlebars': require('oc-template-handlebars').getInfo()
+            .version,
+          'oc-template-jade': require('oc-template-jade').getInfo().version
+        });
         expect(result.headers['user-agent']).to.equal(
           'oc-client-1.2.3/v0.10.40-darwin-x64'
         );

--- a/test/unit/client-warmup.js
+++ b/test/unit/client-warmup.js
@@ -3,9 +3,21 @@
 const expect = require('chai').expect;
 const injectr = require('injectr');
 const sinon = require('sinon');
+const format = require('stringformat');
+
 const handlebarsTemplateVersion = require('oc-template-handlebars').getInfo()
   .version;
 const jadeTemplateVersion = require('oc-template-jade').getInfo().version;
+
+const getDefaultUserAgent = function() {
+  return format(
+    'oc-client-{0}/{1}-{2}-{3}',
+    require('../../package.json').version,
+    process.version,
+    process.platform,
+    process.arch
+  );
+};
 
 describe('client : warmup', () => {
   let Warmup, requestStub;
@@ -169,7 +181,7 @@ describe('client : warmup', () => {
         json: true,
         headers: {
           'accept-language': 'en-US',
-          'user-agent': 'oc-client-2.1.22/v8.2.1-darwin-x64',
+          'user-agent': getDefaultUserAgent(),
           templates: {
             'oc-template-handlebars': handlebarsTemplateVersion,
             'oc-template-jade': jadeTemplateVersion

--- a/test/unit/client-warmup.js
+++ b/test/unit/client-warmup.js
@@ -3,6 +3,9 @@
 const expect = require('chai').expect;
 const injectr = require('injectr');
 const sinon = require('sinon');
+const handlebarsTemplateVersion = require('oc-template-handlebars').getInfo()
+  .version;
+const jadeTemplateVersion = require('oc-template-jade').getInfo().version;
 
 describe('client : warmup', () => {
   let Warmup, requestStub;
@@ -164,7 +167,14 @@ describe('client : warmup', () => {
       const expectedRequest = {
         url: 'https://my-registry.com/component1/~info',
         json: true,
-        headers: { 'Accept-Language': 'en-US' },
+        headers: {
+          'accept-language': 'en-US',
+          'user-agent': 'oc-client-2.1.22/v8.2.1-darwin-x64',
+          templates: {
+            'oc-template-handlebars': handlebarsTemplateVersion,
+            'oc-template-jade': jadeTemplateVersion
+          }
+        },
         method: 'GET',
         timeout: 5
       };

--- a/test/unit/utils-helpers.js
+++ b/test/unit/utils-helpers.js
@@ -1,0 +1,19 @@
+const expect = require('chai').expect;
+
+const _ = require('../../src/utils/helpers');
+
+describe('_.uniq', () => {
+  describe('when array contain duplicates', () => {
+    it('should return an array duplicates-free', () => {
+      expect(_.uniq([1, 1, 'a', 3, 4, 5, 5, 6, 'b', 'a'])).to.deep.equal([
+        1,
+        'a',
+        3,
+        4,
+        5,
+        6,
+        'b'
+      ]);
+    });
+  });
+});

--- a/test/unit/utils-helpers.js
+++ b/test/unit/utils-helpers.js
@@ -6,12 +6,12 @@ describe('_.uniq', () => {
   describe('when array contain duplicates', () => {
     it('should return an array duplicates-free', () => {
       expect(_.uniq([1, 1, 'a', 3, 4, 5, 5, 6, 'b', 'a'])).to.deep.equal([
-        1,
+        '1',
+        '3',
+        '4',
+        '5',
+        '6',
         'a',
-        3,
-        4,
-        5,
-        6,
         'b'
       ]);
     });


### PR DESCRIPTION
Context: this will allow for example for React SSR to delegate to the Registry for the rendering, in case the template is not supported by the client.

https://opentable.atlassian.net/browse/OC-93