### PR TITLE
[OC-93b] Serialize template information in headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It will create an instance of the client. Options:
 |`registries`|`object`|yes|The registries' endpoints|
 |`registries.serverRendering`|`string`|no|The baseUrl for server-side rendering requests|
 |`registries.clientRendering`|`string`|no|The baseUrl for client-side rendering requests|
-|`templates`|`array`|no|The templates available to the client, will extend the default: ['oc-template-handlebars', 'oc-template-jade']|
+|`templates`|`array`|no|The templates available to the client, will extend the default: [require('oc-template-handlebars'), require('oc-template-jade')]|
 
 Example:
 

--- a/test/acceptance/client.js
+++ b/test/acceptance/client.js
@@ -233,10 +233,7 @@ describe('The node.js OC client', () => {
           method: 'post',
           headers: {
             'user-agent': 'oc-client-(.*?)',
-            templates: {
-              'oc-template-handlebars': '6.0.2',
-              'oc-template-jade': '6.0.1'
-            },
+            templates: 'oc-template-handlebars,6.0.2;oc-template-jade,6.0.1',
             accept: 'application/vnd.oc.unrendered+json'
           },
           timeout: 5,
@@ -660,10 +657,7 @@ describe('The node.js OC client', () => {
         method: 'get',
         headers: {
           'user-agent': 'oc-client-(.*?)',
-          templates: {
-            'oc-template-handlebars': '6.0.2',
-            'oc-template-jade': '6.0.1'
-          },
+          templates: 'oc-template-handlebars,6.0.2;oc-template-jade,6.0.1',
           accept: 'application/vnd.oc.unrendered+json'
         },
         timeout: 5,
@@ -786,10 +780,7 @@ describe('The node.js OC client', () => {
             headers: {
               'accept-language': 'da, en-gb;q=0.8, en;q=0.7',
               'user-agent': 'oc-client-(.*?)',
-              templates: {
-                'oc-template-handlebars': '6.0.2',
-                'oc-template-jade': '6.0.1'
-              },
+              templates: 'oc-template-handlebars,6.0.2;oc-template-jade,6.0.1',
               accept: 'application/vnd.oc.unrendered+json'
             },
             timeout: 5,
@@ -831,10 +822,7 @@ describe('The node.js OC client', () => {
           method: 'get',
           headers: {
             'user-agent': 'oc-client-(.*?)',
-            templates: {
-              'oc-template-handlebars': '6.0.2',
-              'oc-template-jade': '6.0.1'
-            },
+            templates: 'oc-template-handlebars,6.0.2;oc-template-jade,6.0.1',
             accept: 'application/vnd.oc.unrendered+json'
           },
           timeout: 5,
@@ -867,10 +855,7 @@ describe('The node.js OC client', () => {
           method: 'get',
           headers: {
             'user-agent': 'oc-client-(.*?)',
-            templates: {
-              'oc-template-handlebars': '6.0.2',
-              'oc-template-jade': '6.0.1'
-            },
+            templates: 'oc-template-handlebars,6.0.2;oc-template-jade,6.0.1',
             accept: 'application/vnd.oc.unrendered+json'
           },
           timeout: 0.01,
@@ -992,10 +977,7 @@ describe('The node.js OC client', () => {
         method: 'post',
         headers: {
           'user-agent': 'oc-client-(.*?)',
-          templates: {
-            'oc-template-handlebars': '6.0.2',
-            'oc-template-jade': '6.0.1'
-          },
+          templates: 'oc-template-handlebars,6.0.2;oc-template-jade,6.0.1',
           accept: 'application/vnd.oc.info+json'
         },
         timeout: 5,

--- a/test/unit/client-sanitiser.js
+++ b/test/unit/client-sanitiser.js
@@ -26,11 +26,9 @@ describe('client : sanitiser', () => {
       const result = sanitiser.sanitiseGlobalRenderOptions({}, config);
 
       it('should set oc-client user-agent', () => {
-        expect(result.headers.templates).to.deep.equal({
-          'oc-template-handlebars': require('oc-template-handlebars').getInfo()
-            .version,
-          'oc-template-jade': require('oc-template-jade').getInfo().version
-        });
+        expect(result.headers.templates).to.equal(
+          'oc-template-handlebars,6.0.2;oc-template-jade,6.0.1'
+        );
         expect(result.headers['user-agent']).to.equal(
           'oc-client-1.2.3/v0.10.40-darwin-x64'
         );

--- a/test/unit/client-warmup.js
+++ b/test/unit/client-warmup.js
@@ -182,10 +182,7 @@ describe('client : warmup', () => {
         headers: {
           'accept-language': 'en-US',
           'user-agent': getDefaultUserAgent(),
-          templates: {
-            'oc-template-handlebars': handlebarsTemplateVersion,
-            'oc-template-jade': jadeTemplateVersion
-          }
+          templates: `oc-template-handlebars,${handlebarsTemplateVersion};oc-template-jade,${jadeTemplateVersion}`
         },
         method: 'GET',
         timeout: 5


### PR DESCRIPTION
- [x] template headers format: 'template-type1,X.X.X;template-type2,X.X.X'
- [x] Explicit api to pass templates to config `[require(template-type3), require(template-type4)]`