### PR TITLE
[DX-153] Sanitize fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "cheerio": "0.22.0",
     "injectr": "0.5.1",
     "mocha": "^3.0.2",
-    "oc": "^0.40.9",
+    "oc": "^0.41.2",
     "sinon": "^3.1.0",
     "husky": "^0.14.3",
-    "prettier-eslint-cli": "^4.1.1",
+    "prettier-eslint-cli": "4.3.0",
     "lint-staged": "^4.0.3"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cheerio": "0.22.0",
     "injectr": "0.5.1",
     "mocha": "^3.0.2",
-    "oc": "^0.41.2",
+    "oc": "^0.40.9",
     "sinon": "^3.1.0",
     "husky": "^0.14.3",
     "prettier-eslint-cli": "4.3.0",

--- a/src/sanitiser.js
+++ b/src/sanitiser.js
@@ -56,11 +56,13 @@ module.exports = {
     const confCopy = Object.assign({}, conf);
     confCopy.components = confCopy.components || {};
     confCopy.cache = confCopy.cache || {};
-    confCopy.templates = confCopy.templates
-      ? _.uniq(getTemplatesInfo(confCopy.templates.concat(baseTemplates))).join(
-          ';'
-        )
-      : getTemplatesInfo(baseTemplates).join(';');
+    if (confCopy.templates && Array.isArray(confCopy.templates)) {
+      confCopy.templates = _.uniq(
+        getTemplatesInfo(confCopy.templates.concat(baseTemplates))
+      ).join(';');
+    } else if (!confCopy.templates) {
+      confCopy.templates = getTemplatesInfo(baseTemplates).join(';');
+    }
 
     return confCopy;
   },


### PR DESCRIPTION
- Couple of small updates (prettier-eslint-cli pinned to 4.3.0 because of [this)](https://github.com/prettier/prettier-eslint-cli/issues/105)
- Fixes the case where the templates were already sanitized. (If no config.templates, they get initialized with coreTemplates, if a valid array of templates is passed it get extended with them, in all the other cases there is no override)
