### PR TITLE
updated validator to check for clientRendering in registries object

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -17,7 +17,7 @@ module.exports = {
     } else if (
       !!conf.registries &&
       !conf.registries.serverRendering &&
-      !conf.clientRendering
+      !conf.registries.clientRendering
     ) {
       return errorMessage(settings.registriesEmpty);
     }

--- a/test/unit/client-validator.js
+++ b/test/unit/client-validator.js
@@ -31,5 +31,29 @@ describe('client : validator', () => {
         );
       });
     });
+
+    describe('when registries contains serverRendering only', () => {
+      const result = validator.validateConfiguration({
+        registries: {
+          serverRendering: 'http://localhost:3030'
+        }
+      });
+
+      it('should pass', () => {
+        expect(result.isValid).to.be.true;
+      });
+    });
+
+    describe('when registries contains clientRendering only', () => {
+      const result = validator.validateConfiguration({
+        registries: {
+          clientRendering: 'http://localhost:3030'
+        }
+      });
+
+      it('should pass', () => {
+        expect(result.isValid).to.be.true;
+      });
+    });
   });
 });


### PR DESCRIPTION
Hey,

It looks like the validator isn't checking for the presence of `clientRendering` in the expected place. It currently checks for it in the root of the `conf` object, however the docs and the rest of the code seem to expect it to be located in the `registries` object.

I've updated the validator to check for `clientRendering` in `registries` (along side `serverRendering`) and I've added tests to cover this.

To recreate the original issue, you can create an instance of the client with only `clientRendering` in the registries to see the validation fail.


Cheers,
Dan