### PR TITLE
[DX-253] Some optimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@ language: node_js
 
 matrix:
   include:
-    - node_js: "4"
-    - node_js: "5"
     - node_js: "6"
     - node_js: "7"
     - node_js: "8"
+    - node_js: "9"
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Node.js client for [OpenComponents](https://github.com/opentable/oc)
 
 [![NPM](https://nodei.co/npm/oc-client.png?downloads=true)](https://npmjs.org/package/oc-client)
 
-Node.js version: **4** required
+Node.js version: **6** required
 
 Build status: Linux: [![Build Status](https://secure.travis-ci.org/opencomponents/oc-client-node.png?branch=master)](http://travis-ci.org/opencomponents/oc-client-node) | Windows:[![Build status](https://ci.appveyor.com/api/projects/status/nna1ahayjx5h6d66?svg=true)](https://ci.appveyor.com/project/OpenComponents/oc-client-node)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,10 @@ version: "{build}"
 # what combinations to test
 environment:
   matrix:
-    - nodejs_version: 4
-    - nodejs_version: 5
     - nodejs_version: 6
     - nodejs_version: 7
     - nodejs_version: 8
+    - nodejs_version: 9
 
 # Get the stable version of node
 install:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-client",
-  "version": "2.1.33",
+  "version": "2.1.34",
   "description": "Node.js oc client",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-client",
-  "version": "2.1.34",
+  "version": "3.0.0",
   "description": "Node.js oc client",
   "main": "index.js",
   "repository": {

--- a/src/html-renderer.js
+++ b/src/html-renderer.js
@@ -1,29 +1,19 @@
 'use strict';
 
-const format = require('stringformat');
-
 const templates = require('./templates');
 
 module.exports = {
-  renderedComponent: function(data) {
+  renderedComponent: data => {
     if (!!data.name && data.renderInfo !== false) {
-      data.html += format(templates.renderInfo, data.name, data.version);
+      data.html += templates.renderInfo(data);
     }
 
     if (data.container !== false) {
-      data.html = format(
-        templates.componentTag,
-        data.href,
-        data.key,
-        data.name || '',
-        data.version,
-        data.html
-      );
+      data.html = templates.componentTag(data);
     }
 
     return data.html;
   },
-  unrenderedComponent: function(href) {
-    return href ? format(templates.componentUnrenderedTag, href) : '';
-  }
+  unrenderedComponent: href =>
+    href ? templates.componentUnrenderedTag({ href }) : ''
 };

--- a/src/process-client-responses.js
+++ b/src/process-client-responses.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const format = require('stringformat');
-
 const GetOCClientScript = require('./get-oc-client-script');
 const HrefBuilder = require('./href-builder');
 const htmlRenderer = require('./html-renderer');
@@ -48,11 +46,10 @@ module.exports = function(cache, config) {
             );
 
             if (action.failover) {
-              action.result.html = format(
-                templates.clientScript,
+              action.result.html = templates.clientScript({
                 clientJs,
                 unrenderedComponentTag
-              );
+              });
             } else {
               action.result.error = null;
               action.result.html = unrenderedComponentTag;

--- a/src/sanitiser.js
+++ b/src/sanitiser.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const format = require('stringformat');
-
 const packageInfo = require('../package');
 const _ = require('./utils/helpers');
 
@@ -15,15 +13,8 @@ const lowerHeaderKeys = function(headers) {
   return result;
 };
 
-const getDefaultUserAgent = function() {
-  return format(
-    'oc-client-{0}/{1}-{2}-{3}',
-    packageInfo.version,
-    process.version,
-    process.platform,
-    process.arch
-  );
-};
+const getDefaultUserAgent = () =>
+  `oc-client-${packageInfo.version}/${process.version}-${process.platform}-${process.arch}`;
 
 const getTemplatesInfo = templates =>
   templates.map(template => {

--- a/src/template-renderer.js
+++ b/src/template-renderer.js
@@ -3,7 +3,7 @@
 const htmlRenderer = require('./html-renderer');
 const requireTemplate = require('./utils/require-template');
 
-const isTemplateLegacy = t => !!{ handlebars: true, jade: true }[t];
+const isTemplateLegacy = t => t === 'handlebars' || t === 'jade';
 
 module.exports = function() {
   return function(template, model, options, callback) {

--- a/src/template-renderer.js
+++ b/src/template-renderer.js
@@ -3,19 +3,19 @@
 const htmlRenderer = require('./html-renderer');
 const requireTemplate = require('./utils/require-template');
 
+const isTemplateLegacy = t => !!{ handlebars: true, jade: true }[t];
+
 module.exports = function() {
   return function(template, model, options, callback) {
-    const key = { options };
-    let type = options.templateType;
-    if (type === 'jade') {
-      type = 'oc-template-jade';
-    }
-    if (type === 'handlebars') {
-      type = 'oc-template-handlebars';
+    const { key } = options;
+    let { templateType } = options;
+
+    if (isTemplateLegacy(templateType)) {
+      templateType = `oc-template-${templateType}`;
     }
 
     try {
-      const ocTemplate = requireTemplate(type);
+      const ocTemplate = requireTemplate(templateType);
       ocTemplate.render({ key, model, template }, (err, html) => {
         options.html = html;
         return callback(err, htmlRenderer.renderedComponent(options));

--- a/src/template-renderer.js
+++ b/src/template-renderer.js
@@ -5,6 +5,7 @@ const requireTemplate = require('./utils/require-template');
 
 module.exports = function() {
   return function(template, model, options, callback) {
+    const key = { options };
     let type = options.templateType;
     if (type === 'jade') {
       type = 'oc-template-jade';
@@ -15,7 +16,7 @@ module.exports = function() {
 
     try {
       const ocTemplate = requireTemplate(type);
-      ocTemplate.render({ template, model }, (err, html) => {
+      ocTemplate.render({ key, model, template }, (err, html) => {
         options.html = html;
         return callback(err, htmlRenderer.renderedComponent(options));
       });

--- a/src/templates.js
+++ b/src/templates.js
@@ -1,14 +1,16 @@
 'use strict';
 
 module.exports = {
-  clientScript: '<script class="ocClientScript">{0}</script>{1}',
+  clientScript: ({ clientJs, unrenderedComponentTag }) =>
+    `<script class="ocClientScript">${clientJs}</script>${unrenderedComponentTag}`,
 
-  componentTag:
-    '<oc-component href="{0}" data-hash="{1}" data-name="{2}" data-rendered="true" data-version="{3}">{4}</oc-component>',
+  componentTag: ({ href, html, key, name, version }) =>
+    `<oc-component href="${href}" data-hash="${key}" data-name="${name ||
+      ''}" data-rendered="true" data-version="${version}">${html}</oc-component>`,
 
-  componentUnrenderedTag: '<oc-component href="{0}"></oc-component>',
+  componentUnrenderedTag: ({ href }) =>
+    `<oc-component href="${href}"></oc-component>`,
 
-  renderInfo:
-    '<script>window.oc=window.oc||{};oc.renderedComponents=oc.renderedComponents||{};' +
-    'oc.renderedComponents["{0}"]="{1}";</script>'
+  renderInfo: ({ name, version }) =>
+    `<script>window.oc=window.oc||{};oc.renderedComponents=oc.renderedComponents||{};oc.renderedComponents["${name}"]="${version}";</script>`
 };


### PR DESCRIPTION
This includes 2 changes:
1) Removes the use of stringformat for rendering porposes - ideally slightly improving performance,
2) Pass the key (template hash) to the template renderer. This could be useful as in the handlebars renderer I want to play with the idea of having a cache of precompiled templates by hash - which should make the handlebars rendering possibly twice as fast (as it would just do the rendering and skip the precompile (https://github.com/opencomponents/base-templates/blob/master/packages/oc-template-handlebars/lib/render.js#L11)

Also, let's stop supporting node 4 and make 6 now that 8 is LTS.