### PR TITLE
updated readme to reflect the code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Options:
 
 |Parameter|type|mandatory|description|
 |---------|----|---------|-----------|
-|`container`|`boolean`|no|Default true, when false, renders a component without its <oc-component> container|
+|`container`|`boolean`|no|Default false, when false, renders a component without its <oc-component> container|
 |`disableFailoverRendering`|`boolean`|no|Disables the automatic failover rendering in case the registry times-out (in case configuration.registries.clientRendering contains a valid value.) Default false|
 |`forwardAcceptLanguageToClient`|`boolean`|no|When not specified in config, defaults to false. When true, when doing client-side requests (normal or failover) appends a custom parameter to the browser's component hrefs so that the framework will ignore the browser's Accept-Language in favour of the query-string value|
 |`headers`|`object`|no|An object containing all the headers that must be forwarded to the component|


### PR DESCRIPTION
Turns out that container is false by default: https://github.com/opencomponents/oc-client-node/blob/master/src/sanitiser.js#L66