### PR TITLE
fix for "renderComponents is not defined" when calling the init method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,8 +31,8 @@ module.exports = function(conf) {
 
   return {
     init: function(options, callback) {
-      const renderComponents = options.renderComponents || renderComponents;
-      const warmup = new Warmup(config, renderComponents);
+      const _renderComponents = options.renderComponents || renderComponents;
+      const warmup = new Warmup(config, _renderComponents);
       return warmup(options, callback);
     },
     renderComponent: function(componentName, options, callback) {


### PR DESCRIPTION
Following the documentation on the README leads to an error when calling the init method (assuming you don't pass in a renderComponents method as an option). This PR fixes it for me on my side.