### PR TITLE
render id on tag if passed on the model

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-client",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Node.js oc client",
   "main": "index.js",
   "repository": {

--- a/src/templates.js
+++ b/src/templates.js
@@ -4,8 +4,8 @@ module.exports = {
   clientScript: ({ clientJs, unrenderedComponentTag }) =>
     `<script class="ocClientScript">${clientJs}</script>${unrenderedComponentTag}`,
 
-  componentTag: ({ href, html, key, name, version }) =>
-    `<oc-component href="${href}" data-hash="${key}" data-name="${name ||
+  componentTag: ({ href, html, key, name, version, id }) =>
+    `<oc-component href="${href}" data-hash="${key}" ${id ? `data-id="${id}"` : ''} data-name="${name ||
       ''}" data-rendered="true" data-version="${version}">${html}</oc-component>`,
 
   componentUnrenderedTag: ({ href }) =>


### PR DESCRIPTION
the newer templates, when streaming, will save the data on oc.__data[id], so data not serialisable (promises, date) can be accessed from the template. so the id needs to be passed to ssr to know where to fetch it back